### PR TITLE
PF-Tabs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,19 @@ URL: http://localhost:3000/index.html
 ![image](https://cloud.githubusercontent.com/assets/12733153/20062925/69b80140-a4d3-11e6-87d7-b2f523b1b869.png)
 
 ## Tech Notes
-
 Repository uses the following:
 
 * Bable - Essentially an ECMAScript 6 to ECMAScript 5 Javascript compiler. It allows you to use ES6 features in your projects and then compiles ES5 for you to use in production.
 * Plumber - Prevent pipe breaking caused by errors from gulp plugins
 * Webpack - Webpack is a module bundler. Webpack takes modules with dependencies and generates static assets representing those modules.
+
+## Gotchas
+Currently, when inheriting from HTMLElement with ES6/Babel, you may receive a `Super expression must either be null or a function` error in Safari. To circumvent this, you may want to include the following shim in you code (which will ensure HTMLElement is of type Function and not Object):
+```
+if (typeof HTMLElement !== 'function'){
+  var _HTMLElement = function(){};
+  _HTMLElement.prototype = HTMLElement.prototype;
+  HTMLElement = _HTMLElement;
+}
+```
+[Source](https://github.com/babel/babel/issues/1548)

--- a/src/pf-tabs/index.html
+++ b/src/pf-tabs/index.html
@@ -13,10 +13,10 @@
       <h1>Tabs</h1>
     </div>
     <pf-tabs>
-      <pf-tab title="Tab1" active="true">
+      <pf-tab tabTitle="Tab1" active="true">
         <p>Tab1 content here</p>
       </pf-tab>
-      <pf-tab title="Tab2">
+      <pf-tab tabTitle="Tab2">
         <p>Tab2 content here</p>
       </pf-tab>
     </pf-tabs>

--- a/src/pf-tabs/pf-tab.component.js
+++ b/src/pf-tabs/pf-tab.component.js
@@ -5,15 +5,15 @@ import {default as tmpl} from 'panel.template';
  *
  * @example {@lang xml}
  * <pf-tabs>
- *  <pf-tab title="Tab1" active="true">
+ *  <pf-tab tabTitle="Tab1" active="true">
  *    <p>Tab1 content here</p>
  *  </pf-tab>
- *  <pf-tab title="Tab2">
+ *  <pf-tab tabTitle="Tab2">
  *    <p>Tab2 content here</p>
  *  </pf-tab>
  * </pf-tabs>
  *
- * @prop {string} title the tab title
+ * @prop {string} tabTitle the tab title
  * @prop {string} active if attribute exists, tab will be active
  */
 export class PfTab extends HTMLElement {
@@ -33,7 +33,7 @@ export class PfTab extends HTMLElement {
    */
   attributeChangedCallback (attrName, oldValue, newValue) {
     var parent = this.parentNode;
-    if (attrName === 'title' && parent && parent.handleTitle) {
+    if (attrName === 'tabTitle' && parent && parent.handleTitle) {
       parent.handleTitle(this, newValue);
     }
   }
@@ -47,23 +47,23 @@ export class PfTab extends HTMLElement {
   }
 
   /**
-   * Get tab title
+   * Get tabTitle
    *
-   * @returns {string} The tab title
+   * @returns {string} The tabTitle
    */
-  get title () {
-    return this._title;
+  get tabTitle () {
+    return this._tabTitle;
   }
 
   /**
-   * Set tab title
+   * Set tab tabTitle
    *
-   * @param {string} value The tab title
+   * @param {string} value The tab tabTitle
    */
-  set title (value) {
-    if (this._title !== value) {
-      this._title = value;
-      this.setAttribute('title', value);
+  set tabTitle (value) {
+    if (this._tabTitle !== value) {
+      this._tabTitle = value;
+      this.setAttribute('tabTitle', value);
     }
   }
 

--- a/src/pf-tabs/pf-tabs.component.js
+++ b/src/pf-tabs/pf-tabs.component.js
@@ -7,10 +7,10 @@ import PfTab from 'pf-tab.component';
  *
  * @example {@lang xml}
  * <pf-tabs>
- *  <pf-tab title="Tab1" active="true">
+ *  <pf-tab tabTitle="Tab1" active="true">
  *    <p>Tab1 content here</p>
  *  </pf-tab>
- *  <pf-tab title="Tab2">
+ *  <pf-tab tabTitle="Tab2">
  *    <p>Tab2 content here</p>
  *  </pf-tab>
  * </pf-tabs>
@@ -154,18 +154,31 @@ export class PfTabs extends HTMLElement {
   }
 
   /**
-   * Handle the title change event
+   * Handle the tabTitle change event
    *
    * @param panel {string} The tab panel
-   * @param title {string} The tab title
+   * @param tabTitle {string} The tab title
    */
-  handleTitle (panel, title) {
+  handleTitle (panel, tabTitle) {
     let tab = this.panelMap.get(panel);
     //attribute changes may fire as Angular is rendering
     //before this tab is in the panelMap, so check first
     if (tab) {
-      tab.textContent = panel.title;
+      tab.textContent = panel.tabTitle;
     }
+  }
+
+  /**
+   * Sets the active tab programmatically
+   * @param tabTitle
+   */
+  setActiveTab (tabTitle) {
+    this.tabMap.forEach((value, key) => {
+      let tabtitle = value.attributes.tabtitle ? value.attributes.tabtitle.value : value.tabtitle;
+      if (tabtitle === tabTitle) {
+        this._setTabStatus(key);
+      }
+    });
   }
 
   /**
@@ -203,8 +216,8 @@ export class PfTabs extends HTMLElement {
     let tab = frag.content.firstElementChild;
     let tabAnchor = tab.firstElementChild;
     //React gives us a node with attributes, Angular adds it as a property
-    tabAnchor.innerHTML = pfTab.attributes && pfTab.attributes.title ?
-      pfTab.attributes.title.value : pfTab.title;
+    tabAnchor.innerHTML = pfTab.attributes && pfTab.attributes.tabTitle ?
+      pfTab.attributes.tabTitle.value : pfTab.tabTitle;
     this.displayMap.set(pfTab, pfTab.style.display);
     return tab;
   }
@@ -240,19 +253,32 @@ export class PfTabs extends HTMLElement {
    * Helper function to set tab status
    *
    * @param {boolean} active True if active
+   * @param {string} tabtitle the tab title
    * @private
    */
   _setTabStatus (active) {
+    //dispatch the custom 'tabChanged' event for framework listeners
+    var eventObj = new CustomEvent('tabChanged', {
+      detail: activeTabTitle
+    });
+
     if (active === this.selected) {
       return;
     }
     this.selected = active;
 
+    let activeTabTitle;
     let tabs = this.querySelector('ul').children;
     [].forEach.call(tabs, function (tab) {
+      if (active === tab) {
+        activeTabTitle = tab.querySelector('a').text;
+      }
       let fn = active === tab ? this._makeActive : this._makeInactive;
       fn.call(this, tab);
     }.bind(this));
+
+
+    this.dispatchEvent(eventObj);
   }
 }
 (function () {


### PR DESCRIPTION
* changing the title attribute to tabTitle will prevent the annoying Chrome tooltip that gets added to tab content area
* adding an event for 'tabChanged' to expose this to outside frameworks
* adding a setActiveTab method to expose this functionality to outside frameworks via function (and not just active attribute)