### PR TITLE
update unit-test documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ URL: http://localhost:3000/index.html
 
 ![image](https://cloud.githubusercontent.com/assets/12733153/20062925/69b80140-a4d3-11e6-87d7-b2f523b1b869.png)
 
+### Testing
+Unit and Peformance test notes can be found in [TESTS.md](TESTS.md)
+
 ## Tech Notes
 Repository uses the following:
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,6 +1,42 @@
 # Testing Patternfly-Webcomponents
 
 ### Unit Tests
+Unit tests are run with [Karma](https://karma-runner.github.io/1.0/index.html) and [karma-phantomjs-launcher](https://github.com/karma-runner/karma-phantomjs-launcher).
+
+To run unit tests, simply run:
+```
+gulp test
+```
+
+To debug unit tests locally with karma test server and Chrome, first edit `karma.conf.js` to target Chrome:
+```
+  browsers: ['Chrome'],
+```
+You can also change `logLevel` for futher debug logging:
+```
+logLevel: config.LOG_DEBUG,
+```
+
+ you can then run the following to start a Karma debug server:
+ ```
+ karma start karma.conf.js
+ ```
+(then hit the "DEBUG" button in the top right to debug)
+
+ To debug unit tests locally with Phantom JS, edit `karma.conf.js` to target Phantom:
+ ```
+  browsers: ['PhantomJS'],
+```
+
+you can then run:
+```
+karma start --browsers PhantomJS_custom
+```
+
+This will launch a local PhantomJS debug server, which you can access here:
+```
+http://localhost:9000/webkit/inspector/inspector.html?page=2
+```
 
 ### Performance Tests
 This project makes use of [Sitespeed.io](https://www.sitespeed.io/) for web performance tests. 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       'node_modules/babel-polyfill/dist/polyfill.js',
+      'node_modules/promise-polyfill/promise.js',
       'node_modules/jasmine-promises/dist/jasmine-promises.js',
       'node_modules/webcomponentsjs/full.js',
       'dist/js/patternfly.js',
@@ -60,6 +61,26 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['PhantomJS'],
+
+    // you can define custom flags
+    customLaunchers: {
+      'PhantomJS_custom': {
+        base: 'PhantomJS',
+        options: {
+          windowName: 'my-window',
+          settings: {
+            webSecurityEnabled: false
+          },
+        },
+        flags: ['--load-images=true'],
+        debug: true
+      }
+    },
+
+    phantomjsLauncher: {
+      // Have phantomjs exit if a ResourceError is encountered (useful if karma exits without killing phantom)
+      exitOnResourceError: true
+    },
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "karma-phantomjs-launcher": "^1.0.2",
     "patternfly-eng-publish": "0.0.3",
     "patternfly-eng-release": "3.21.0",
+    "promise-polyfill": "^6.0.2",
     "run-sequence": "^1.2.2",
     "webpack": "~1.13.2",
     "webpack-bundle-analyzer": "^1.4.2",

--- a/src/pf-tooltip/pf-tooltip.component.js
+++ b/src/pf-tooltip/pf-tooltip.component.js
@@ -311,7 +311,6 @@ export class PfTooltip extends HTMLElement {
       this.tooltip.style.top = `${rect.top + scroll.y - tooltipDimensions.h / 2 + linkDimensions.h / 2}px`;
       this.tooltip.style.left = `${rect.left + scroll.x + linkDimensions.w}px`;
     }
-    !this.tooltip.className.includes(this._placement) && (this.tooltip.className = this.tooltip.className.replace(this._tipPositions, this._placement));
   }
 
   /**


### PR DESCRIPTION
* add link to TESTs.md in README.md
* add Unit Test debugging instructions
* add Promise polyfill and CustomPhantom config for debugging PhantomJS on Mac
* remove tooltip className correction utility. This wasn't really needed and it actually breaks PhantomJS on Mac b/c of this [issue](https://github.com/ariya/phantomjs/issues/14608) with `.includes()`

