### PR TITLE
fix relative paths for building test pages in Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ URL: http://localhost:3000/index.html
 ### Testing
 Unit and Peformance test notes can be found in [TESTS.md](TESTS.md)
 
+Test pages for each component can also be found at the following url:
+https://rawgit.com/patternfly-webcomponents/patternfly-webcomponents/master-dist/index.html
+
 ## Tech Notes
 Repository uses the following:
 

--- a/app/app.html
+++ b/app/app.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title>Patternfly Doc Page</title>
-  <link rel="stylesheet" href="/dist/css/patternfly.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-additions.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
+  <link rel="stylesheet" href="../dist/css/patternfly.css">
+  <link rel="stylesheet" href="../dist/css/patternfly-additions.css">
+  <link rel="stylesheet" href="../dist/css/patternfly-webcomponents.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
-  <script src="/dist/js/patternfly.js"></script>
+  <script src="../dist/js/patternfly.js"></script>
   <script type="text/javascript">
     function resizeIframe(obj) {
       obj.style.height = obj.contentWindow.document.body.scrollHeight + 100 + 'px';
@@ -55,7 +55,7 @@
         result[item[0]] = decodeURIComponent(item[1]);
       });
 
-      var pathToFile = "/src/" + result.dir + "/" + result.file;
+      var pathToFile = "../src/" + result.dir + "/" + result.file;
       document.getElementById('example').setAttribute('src', pathToFile);
 
       var rawFile = new XMLHttpRequest();

--- a/index.html
+++ b/index.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title>PF Web Components</title>
-  <link rel="stylesheet" href="/dist/css/patternfly.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-additions.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
+  <link rel="stylesheet" href="dist/css/patternfly.css">
+  <link rel="stylesheet" href="dist/css/patternfly-additions.css">
+  <link rel="stylesheet" href="dist/css/patternfly-webcomponents.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
-  <script src="/dist/js/patternfly.js"></script>
+  <script src="dist/js/patternfly.js"></script>
 </head>
 <body>
   <div class="container" style="padding-top: 24px;">

--- a/src/pf-alert/index.html
+++ b/src/pf-alert/index.html
@@ -2,13 +2,13 @@
 <html>
 <head>
   <title>pf-alert example</title>
-  <link rel="stylesheet" href="/dist/css/patternfly.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-additions.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-webcomponents.css">
   <script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
   <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
-  <script src="/dist/js/patternfly.js"></script>
+  <script src="../../dist/js/patternfly.js"></script>
 </head>
 <body>
   <div class="container">

--- a/src/pf-dropdown/index.html
+++ b/src/pf-dropdown/index.html
@@ -3,11 +3,11 @@
 
 <head>
   <title>pf-dropdown example</title>
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/patternfly/3.13.0/css/patternfly.css">
-  <link rel="stylesheet" href="/dist/css/patternfly.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
   <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
-  <script src="/dist/js/patternfly.js"></script>
+  <script src="../../dist/js/patternfly.js"></script>
 </head>
 
 <body>

--- a/src/pf-hello/index.html
+++ b/src/pf-hello/index.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title>pf-hello example</title>
-  <link rel="stylesheet" href="/dist/css/patternfly.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-additions.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-webcomponents.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
-  <script src="/dist/js/patternfly.js"></script>
+  <script src="../../dist/js/patternfly.js"></script>
 </head>
 <body>
   <div class="container">

--- a/src/pf-i18n/alt-example.html
+++ b/src/pf-i18n/alt-example.html
@@ -2,12 +2,12 @@
 <html>
 <head>
   <title>pf-i18n example</title>
-  <link rel="stylesheet" href="/dist/css/patternfly.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-additions.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-webcomponents.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/jed/1.1.1/jed.min.js"></script>
-  <script src="/dist/js/patternfly.js"></script>
+  <script src="../../dist/js/patternfly.js"></script>
   <script>
     var locale = "de-DE";
     var i18n = {

--- a/src/pf-i18n/index.html
+++ b/src/pf-i18n/index.html
@@ -2,15 +2,15 @@
 <html>
 <head>
   <title>pf-i18n example</title>
-  <link rel="localization" href="/app/i18n/fr/patternfly.json" hreflang="fr">
-  <link rel="localization" href="/app/i18n/de-DE/patternfly.json" hreflang="de-DE">
-  <link rel="stylesheet" href="/dist/css/patternfly.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-additions.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
+  <link rel="localization" href="../../app/i18n/fr/patternfly.json" hreflang="fr">
+  <link rel="localization" href="../../app/i18n/de-DE/patternfly.json" hreflang="de-DE">
+  <link rel="stylesheet" href="../../dist/css/patternfly.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-webcomponents.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/jed/1.1.1/jed.min.js"></script>
-  <script src="/dist/js/patternfly.js"></script>
-  <script src="/app/i18n/i18n.js"></script>
+  <script src="../../dist/js/patternfly.js"></script>
+  <script src="../../app/i18n/i18n.js"></script>
 </head>
 <body>
   <pf-i18n mixin="i18n"></pf-i18n>

--- a/src/pf-list-view/index.html
+++ b/src/pf-list-view/index.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title>pf-alert example</title>
-  <link rel="stylesheet" href="/dist/css/patternfly.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-additions.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-webcomponents.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
-  <script src="/dist/js/patternfly.js"></script>
+  <script src="../../dist/js/patternfly.js"></script>
 </head>
 <body>
 <div class="container">

--- a/src/pf-tabs/index.html
+++ b/src/pf-tabs/index.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title>pf-tabs example</title>
-  <link rel="stylesheet" href="/dist/css/patternfly.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-additions.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-webcomponents.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
-  <script src="/dist/js/patternfly.js"></script>
+  <script src="../../dist/js/patternfly.js"></script>
 </head>
 <body>
   <div class="container">

--- a/src/pf-tooltip/index.html
+++ b/src/pf-tooltip/index.html
@@ -2,12 +2,12 @@
 <html>
 <head>
     <title>pf-tooltip example</title>
-    <link rel="stylesheet" href="/dist/css/patternfly.css">
-    <link rel="stylesheet" href="/dist/css/patternfly-additions.css">
-    <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
+    <link rel="stylesheet" href="../../dist/css/patternfly.css">
+    <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
+    <link rel="stylesheet" href="../../dist/css/patternfly-webcomponents.css">
     <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
-    <script src="/dist/js/pf-utils.js"></script>
-    <script src="/dist/js/pf-tooltip.js"></script>
+    <script src="../../dist/js/pf-utils.js"></script>
+    <script src="../../dist/js/pf-tooltip.js"></script>
 </head>
 <body>
 <div class="container">

--- a/src/pf-utilization-bar-chart/index.html
+++ b/src/pf-utilization-bar-chart/index.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title>pf-utilization-bar-chart example</title>
-  <link rel="stylesheet" href="/dist/css/patternfly.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-additions.css">
-  <link rel="stylesheet" href="/dist/css/patternfly-webcomponents.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
+  <link rel="stylesheet" href="../../dist/css/patternfly-webcomponents.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.22/webcomponents.js"></script>
-  <script src="/dist/js/patternfly.js"></script>
+  <script src="../../dist/js/patternfly.js"></script>
 </head>
 <body onload="startThresholdIncrements();">
   <div class="container">


### PR DESCRIPTION
* this makes script paths relative so that test pages can be viewed in Travis in a developer's fork once enabled for Travis builds.

Story: [PTNFLY-2274](https://patternfly.atlassian.net/browse/PTNFLY-2274)