### PR TITLE
adds secondary tabs to pf-tabs

### DIFF
--- a/src/pf-tabs/index.html
+++ b/src/pf-tabs/index.html
@@ -1,22 +1,47 @@
 <!doctype html>
 <html>
+
 <head>
   <title>pf-tabs example</title>
   <link rel="stylesheet" href="../../dist/css/patternfly.css">
   <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
   <link rel="stylesheet" href="../../dist/css/patternfly-webcomponents.css">
 </head>
+
 <body>
   <div class="container">
     <div class="page-header">
       <h1>Tabs</h1>
     </div>
     <pf-tabs>
-      <pf-tab tabTitle="Tab1" active="true">
-        <p>Tab1 content here</p>
+      <pf-tab tabTitle="Tab One" active="true">
+        <p>Tab one content here</p>
       </pf-tab>
-      <pf-tab tabTitle="Tab2">
-        <p>Tab2 content here</p>
+      <pf-tab tabTitle="Tab Two">
+        <p>Tab two content here</p>
+      </pf-tab>
+    </pf-tabs>
+
+    <pf-tabs>
+      <pf-tab tabTitle="Tab One" active="true">
+        <pf-tabs class="nav nav-tabs nav-tabs-pf">
+          <pf-tab tabTitle="Tab One Secondary Tab One" active="true">
+            <p>Tab One Secondary Tab One content.</p>
+          </pf-tab>
+          <pf-tab tabTitle="Tab One Secondary Tab Two">
+            <p>Tab One Secondary Tab Two content.</p>
+          </pf-tab>
+        </pf-tabs>
+      </pf-tab>
+      <pf-tab tabTitle="Tab Two">
+        <pf-tabs class="nav nav-tabs nav-tabs-pf">
+          <pf-tab tabTitle="Tab Two Secondary Tab One" active="true">
+            <p>Tab Two Secondary Tab One content.</p>
+          </pf-tab>
+          <pf-tab tabTitle="Tab Two Secondary Tab Two">
+            <p>Tab Two Secondary Tab Two content.</p>
+          </pf-tab>
+        </pf-tabs>
       </pf-tab>
     </pf-tabs>
   </div>
@@ -24,4 +49,5 @@
   <script src="//rawgit.com/webcomponents/custom-elements/master/src/native-shim.js"></script>
   <script src="../../dist/js/patternfly.js"></script>
 </body>
+
 </html>

--- a/src/pf-tabs/pf-tabs.component.js
+++ b/src/pf-tabs/pf-tabs.component.js
@@ -28,8 +28,9 @@ export class PfTabs extends HTMLElement {
     this.querySelector('ul').addEventListener('click', this);
 
     // Add the ul class if specified
-    this.querySelector('ul').className = this.attributes.class ?
-      this.attributes.class.value : 'nav nav-tabs';
+    this.querySelector('ul').className = this.attributes.class
+      ? this.attributes.class.value
+      : 'nav nav-tabs';
 
     if (!this.mutationObserver) {
       this.mutationObserver = new MutationObserver(this._handleMutations.bind(this));
@@ -200,19 +201,25 @@ export class PfTabs extends HTMLElement {
    */
   _makeTabsFromPfTab () {
     let ul = this.querySelector('ul');
-    let pfTabs = this.querySelectorAll('pf-tab');
-    [].forEach.call(pfTabs, function (pfTab, idx) {
-      let tab = this._makeTab(pfTab);
-      ul.appendChild(tab);
-      this.tabMap.set(tab, pfTab);
-      this.panelMap.set(pfTab, tab);
+    if (this.children && this.children.length) {
+      let pfTabs = [].slice.call(this.children).filter(
+        (node) => {
+          return node.nodeName === 'PF-TAB';
+        }
+      );
+      [].forEach.call(pfTabs, function (pfTab, idx) {
+        let tab = this._makeTab(pfTab);
+        ul.appendChild(tab);
+        this.tabMap.set(tab, pfTab);
+        this.panelMap.set(pfTab, tab);
 
-      if (idx === 0) {
-        this._makeActive(tab);
-      } else {
-        pfTab.style.display = 'none';
-      }
-    }.bind(this));
+        if (idx === 0) {
+          this._makeActive(tab);
+        } else {
+          pfTab.style.display = 'none';
+        }
+      }.bind(this));
+    }
   }
 
   /**

--- a/src/pf-tabs/pf-tabs.scss
+++ b/src/pf-tabs/pf-tabs.scss
@@ -1,0 +1,23 @@
+pf-tabs.nav.nav-tabs .nav.nav-tabs-pf {
+  & > li {
+    font-size: 12px;
+
+    &:first-child > a {
+      padding-left: 15px;
+
+      &:before {
+        left: 15px!important;
+      }
+    }
+  }
+}
+
+pf-tabs.nav.nav-tabs li,
+pf-tabs.nav.nav-tabs li a {
+  cursor: pointer;
+}
+
+pf-tab > *:not(ul):not(pf-tab):not(pf-tabs) {
+  font-size: 14px;
+  padding: 15px;
+}

--- a/src/scss/patternfly-webcomponents.scss
+++ b/src/scss/patternfly-webcomponents.scss
@@ -1,4 +1,5 @@
 @import "src/pf-alert/pf-alert.scss";
+@import "src/pf-tabs/pf-tabs.scss";
 @import "src/pf-tooltip/pf-tooltip.scss";
 @import "src/pf-utilization-bar-chart/pf-utilization-bar-chart.scss";
 @import "src/pf-dropdown/pf-dropdown.scss"


### PR DESCRIPTION
minor tweak to `pf-tabs` to support secondary tabs. 

i've added a test page here just now:
https://rawgit.com/priley86/patternfly-webcomponents/secondary-tabs-dist/app/app.html?dir=pf-tabs&file=index.html

cc @bleathem @dabeng @sahil143 