### PR TITLE
Update attribute names(camelCased to hyphenated)

### DIFF
--- a/src/pf-modal/index.html
+++ b/src/pf-modal/index.html
@@ -13,10 +13,10 @@
     </div>
     
     <button class="btn btn-default" id="btn-toggle-modal">Launch demo modal</button>
-    <pf-modal targetSelector="#btn-toggle-modal" backdrop keyboard>
+    <pf-modal target-selector="#btn-toggle-modal" backdrop keyboard>
       <pf-modal-dialog>
         <pf-modal-content>
-          <pf-modal-header modalTitle="Modal Title"></pf-modal-header>
+          <pf-modal-header modal-title="Modal Title"></pf-modal-header>
           <pf-modal-body>
             <form class="form-horizontal">
               <div class="form-group">

--- a/src/pf-modal/pf-modal-content.component.js
+++ b/src/pf-modal/pf-modal-content.component.js
@@ -4,7 +4,7 @@ import {pfUtil} from 'pf-utils.js';
  * <b>&lt;pf-modal-content&gt;</b> element for Patternfly Web Components
  *
  * @example {@lang xml}
- * <pf-modal targetSelector="#btn-toggle-modal" backdrop keyboard>
+ * <pf-modal target-selector="#btn-toggle-modal" backdrop keyboard>
  *  <pf-modal-dialog>
  *   <pf-modal-content> practical content of pf-modal </pf-modal-content>
  *  </pf-modal-dialog>

--- a/src/pf-modal/pf-modal-dialog.component.js
+++ b/src/pf-modal/pf-modal-dialog.component.js
@@ -4,7 +4,7 @@ import {pfUtil} from 'pf-utils.js';
  * <b>&lt;pf-modal-dialog&gt;</b> element for Patternfly Web Components
  *
  * @example {@lang xml}
- * <pf-modal targetSelector="#btn-toggle-modal" backdrop keyboard>
+ * <pf-modal target-selector="#btn-toggle-modal" backdrop keyboard>
  *  <pf-modal-dialog>
  *   <pf-modal-content> practical content of pf-modal </pf-modal-content>
  *  </pf-modal-dialog>

--- a/src/pf-modal/pf-modal-header.component.js
+++ b/src/pf-modal/pf-modal-header.component.js
@@ -5,7 +5,7 @@ import {default as tmpl} from 'pf-modal-header.template';
  * <b>&lt;pf-modal-header&gt;</b> element for Patternfly Web Components
  *
  * @example {@lang xml}
- * <pf-modal-header modalTitle="Modal Title"></pf-modal-header>
+ * <pf-modal-header modal-title="Modal Title"></pf-modal-header>
  */
 
 export class PfModalHeader extends HTMLElement {
@@ -45,24 +45,24 @@ export class PfModalHeader extends HTMLElement {
   }
 
   /*
-   * Get modalTitle
+   * Get modal-title
    *
    * @returns {string} The modal title
    */
   get modalTitle () {
-    return this.getAttribute('modalTitle');
+    return this.getAttribute('modal-title');
   }
 
   /*
-   * Set modalTitle
+   * Set modal-title
    *
    * @param {string} val Modal title
    */
   set modalTitle (val) {
     if (val) {
-      this.setAttribute('modalTitle', val);
+      this.setAttribute('modal-title', val);
     } else {
-      this.removeAttribute('modalTitle');
+      this.removeAttribute('modal-title');
     }
   }
 
@@ -70,7 +70,7 @@ export class PfModalHeader extends HTMLElement {
    * Only attributes listed in the observedAttributes property will receive this callback
    */
   static get observedAttributes() {
-    return ['modaltitle'];
+    return ['modal-title'];
   }
 
   /*
@@ -81,7 +81,7 @@ export class PfModalHeader extends HTMLElement {
    * @param {string} newValue The new attribute value
    */
   attributeChangedCallback (attrName, oldValue, newValue) {
-    if (attrName === 'modaltitle') {
+    if (attrName === 'modal-title') {
       if (newValue && !oldValue) {
         this._addModalTitle();
       }

--- a/src/pf-modal/pf-modal.component.js
+++ b/src/pf-modal/pf-modal.component.js
@@ -9,17 +9,17 @@ import PfModalFooter from 'pf-modal-footer.component';
  * <b>&lt;pf-modal&gt;</b> element for Patternfly Web Components
  *
  * @example {@lang xml}
- * <pf-modal targetSelector="#btn-toggle-modal" backdrop keyboard>
+ * <pf-modal target-selector="#btn-toggle-modal" backdrop keyboard>
  *   <pf-modal-dialog>
  *     <pf-modal-content>
- *       <pf-modal-header modalTitle="Modal Title"></pf-modal-header>
+ *       <pf-modal-header modal-title="Modal Title"></pf-modal-header>
  *       <pf-modal-body>custom content</pf-modal-body>
  *       <pf-modal-footer></pf-modal-footer>
  *     </pf-modal-content>
  *   </pf-modal-dialog>
  * </pf-modal>
  *
- * @prop {string} targetSelector Indicating which element will fireup the modal
+ * @prop {string} target-selector Indicating which element will fireup the modal
  * @prop {boolean} backdrop Indicating whether Clicking the backdrop could hide the modal or not
  * @prop {boolean} keyboard Indicating whether clicking the escape key could hide the modal or not
  * @prop {boolean} open Indicating whether or not the modal is opend
@@ -118,7 +118,7 @@ export class PfModal extends HTMLElement {
    * Only attributes listed in the observedAttributes property will receive this callback
    */
   static get observedAttributes() {
-    return ['targetselector', 'open', 'keyboard', 'backdrop'];
+    return ['target-selector', 'open', 'keyboard', 'backdrop'];
   }
 
   /*
@@ -129,7 +129,7 @@ export class PfModal extends HTMLElement {
    * @param {string} newValue The new attribute value
    */
   attributeChangedCallback (attrName, oldValue, newValue) {
-    if (attrName === 'targetselector' && newValue !== null && oldValue === null) {
+    if (attrName === 'target-selector' && newValue !== null && oldValue === null) {
       this._target = document.querySelector(newValue);
       if (this._target) {
         this._target.addEventListener('click', this.show.bind(this), false);
@@ -168,8 +168,8 @@ export class PfModal extends HTMLElement {
       this._showModal();
     }
 
-    if (this.getAttribute('targetSelector')) {
-      this._target = document.querySelector(this.getAttribute('targetSelector'));
+    if (this.getAttribute('target-selector')) {
+      this._target = document.querySelector(this.getAttribute('target-selector'));
       if (this._target && !(this._target.getAttribute('data-bound') === 'bound')) {
         this._target.addEventListener('click', this.show.bind(this), false);
       }

--- a/src/pf-modal/pf-modal.spec.js
+++ b/src/pf-modal/pf-modal.spec.js
@@ -15,7 +15,7 @@ describe ('PatternFly Moadl Component Tests', function () {
     mo.observe(document.body, { childList: true });
     render(
       '<button id="btn">Launch demo modal</button>' +
-      '<pf-modal id="modal" targetSelector="#btn" backdrop keyboard>' +
+      '<pf-modal id="modal" target-selector="#btn" backdrop keyboard>' +
       '  <pf-modal-dialog>' +
       '    <pf-modal-content>' +
       '      <pf-modal-header></pf-modal-header>' +

--- a/src/pf-tabs/index.html
+++ b/src/pf-tabs/index.html
@@ -14,31 +14,31 @@
       <h1>Tabs</h1>
     </div>
     <pf-tabs>
-      <pf-tab tabTitle="Tab One" active="true">
+      <pf-tab tab-title="Tab One" active="true">
         <p>Tab one content here</p>
       </pf-tab>
-      <pf-tab tabTitle="Tab Two">
+      <pf-tab tab-title="Tab Two">
         <p>Tab two content here</p>
       </pf-tab>
     </pf-tabs>
 
     <pf-tabs>
-      <pf-tab tabTitle="Tab One" active="true">
+      <pf-tab tab-title="Tab One" active="true">
         <pf-tabs class="nav nav-tabs nav-tabs-pf">
-          <pf-tab tabTitle="Tab One Secondary Tab One" active="true">
+          <pf-tab tab-title="Tab One Secondary Tab One" active="true">
             <p>Tab One Secondary Tab One content.</p>
           </pf-tab>
-          <pf-tab tabTitle="Tab One Secondary Tab Two">
+          <pf-tab tab-title="Tab One Secondary Tab Two">
             <p>Tab One Secondary Tab Two content.</p>
           </pf-tab>
         </pf-tabs>
       </pf-tab>
-      <pf-tab tabTitle="Tab Two">
+      <pf-tab tab-title="Tab Two">
         <pf-tabs class="nav nav-tabs nav-tabs-pf">
-          <pf-tab tabTitle="Tab Two Secondary Tab One" active="true">
+          <pf-tab tab-title="Tab Two Secondary Tab One" active="true">
             <p>Tab Two Secondary Tab One content.</p>
           </pf-tab>
-          <pf-tab tabTitle="Tab Two Secondary Tab Two">
+          <pf-tab tab-title="Tab Two Secondary Tab Two">
             <p>Tab Two Secondary Tab Two content.</p>
           </pf-tab>
         </pf-tabs>

--- a/src/pf-tabs/pf-tab.component.js
+++ b/src/pf-tabs/pf-tab.component.js
@@ -5,15 +5,15 @@ import {default as tmpl} from 'panel.template';
  *
  * @example {@lang xml}
  * <pf-tabs>
- *  <pf-tab tabTitle="Tab1" active="true">
+ *  <pf-tab tab-title="Tab1" active="true">
  *    <p>Tab1 content here</p>
  *  </pf-tab>
- *  <pf-tab tabTitle="Tab2">
+ *  <pf-tab tab-title="Tab2">
  *    <p>Tab2 content here</p>
  *  </pf-tab>
  * </pf-tabs>
  *
- * @prop {string} tabTitle the tab title
+ * @prop {string} tab-title the tab title
  * @prop {string} active if attribute exists, tab will be active
  */
 export class PfTab extends HTMLElement {
@@ -21,6 +21,8 @@ export class PfTab extends HTMLElement {
    * Called every time the element is inserted into the DOM
    */
   connectedCallback () {
+    this._tabTitle = this.getAttribute('tab-title');
+
     this.appendChild(this._template.content);
   }
 
@@ -28,7 +30,7 @@ export class PfTab extends HTMLElement {
    * Only attributes listed in the observedAttributes property will receive this callback
    */
   static get observedAttributes() {
-    return ['tabTitle'];
+    return ['tab-title'];
   }
 
   /**
@@ -40,7 +42,7 @@ export class PfTab extends HTMLElement {
    */
   attributeChangedCallback (attrName, oldValue, newValue) {
     let parent = this.parentNode;
-    if (attrName === 'tabTitle' && parent && parent.handleTitle) {
+    if (attrName === 'tab-title' && parent && parent.handleTitle) {
       parent.handleTitle(this, newValue);
     }
   }
@@ -55,23 +57,23 @@ export class PfTab extends HTMLElement {
   }
 
   /**
-   * Get tabTitle
+   * Get tab-title
    *
-   * @returns {string} The tabTitle
+   * @returns {string} The tab-title
    */
   get tabTitle () {
     return this._tabTitle;
   }
 
   /**
-   * Set tab tabTitle
+   * Set tab tab-title
    *
-   * @param {string} value The tab tabTitle
+   * @param {string} value The tab tab-title
    */
   set tabTitle (value) {
     if (this._tabTitle !== value) {
       this._tabTitle = value;
-      this.setAttribute('tabTitle', value);
+      this.setAttribute('tab-title', value);
     }
   }
 

--- a/src/pf-tabs/pf-tabs.component.js
+++ b/src/pf-tabs/pf-tabs.component.js
@@ -7,10 +7,10 @@ import PfTab from 'pf-tab.component';
  *
  * @example {@lang xml}
  * <pf-tabs>
- *  <pf-tab tabTitle="Tab1" active="true">
+ *  <pf-tab tab-title="Tab1" active="true">
  *    <p>Tab1 content here</p>
  *  </pf-tab>
- *  <pf-tab tabTitle="Tab2">
+ *  <pf-tab tab-title="Tab2">
  *    <p>Tab2 content here</p>
  *  </pf-tab>
  * </pf-tabs>

--- a/src/pf-tooltip/index.html
+++ b/src/pf-tooltip/index.html
@@ -13,22 +13,22 @@
     </div>
     <hr>
 
-    <pf-tooltip id="tooltip-left" placement="left" targetSelector="#btn-left">
+    <pf-tooltip id="tooltip-left" placement="left" target-selector="#btn-left">
         Tooltip text on Left
     </pf-tooltip>
     <button id="btn-left" type="button" class="btn btn-primary" aria-describedby="tooltip-left">Left</button>
 
-    <pf-tooltip id="tooltip-top" placement="top" targetSelector="#btn-top">
+    <pf-tooltip id="tooltip-top" placement="top" target-selector="#btn-top">
         <span>Tooltip on top</span>
     </pf-tooltip>
     <button id="btn-top" type="button" class="btn btn-secondary" aria-describedby="tooltip-top">Top</button>
 
-    <pf-tooltip id="tooltip-bottom" placement="bottom" targetSelector="#btn-bottom">
+    <pf-tooltip id="tooltip-bottom" placement="bottom" target-selector="#btn-bottom">
         <span>Tooltip on bottom</span>
     </pf-tooltip>
     <button id="btn-bottom" type="button" class="btn btn-warning" aria-describedby="tooltip-bottom">Bottom</button>
 
-    <pf-tooltip id="tooltip-right" placement="right" targetSelector="#btn-right">
+    <pf-tooltip id="tooltip-right" placement="right" target-selector="#btn-right">
         <span>Tooltip on right</span>
     </pf-tooltip>
     <button id="btn-right" type="button" class="btn btn-danger" aria-describedby="tooltip-right">Right</button>
@@ -41,7 +41,7 @@
     <script src="../../dist/js/patternfly.js"></script>
     <script>
         setTimeout(function(){
-          var pfTooltipRight = document.querySelector('[targetSelector="#btn-right"]');
+          var pfTooltipRight = document.querySelector('[target-selector="#btn-right"]');
           pfTooltipRight.setInnerHtml("<span>Right content changed!</span>");
         });
     </script>

--- a/src/pf-tooltip/pf-tooltip.component.js
+++ b/src/pf-tooltip/pf-tooltip.component.js
@@ -5,14 +5,14 @@ import {pfUtil} from 'pf-utils.js';
  * <b>&lt;pf-tooltip&gt;</b> element for Patternfly Web Components
  *
  * @example {@lang xml}
- * <pf-tooltip animation="fade" targetSelector="#btn-left" placement="left" delay="100" duration="150" containerSelector="#container"></pf-alert>
+ * <pf-tooltip animation="fade" target-selector="#btn-left" placement="left" delay="100" duration="150" container-selector="#container"></pf-alert>
  *
  * @prop {string} animation the animation class
- * @prop {string} targetSelector the target element selector
+ * @prop {string} target-selector the target element selector
  * @prop {string} placement left, right, top, bottom
  * @prop {number} delay animation delay (ms)
  * @prop {number} duration animation duration (ms)
- * @prop {string} containerSelector the container element selector
+ * @prop {string} container-selector the container element selector
  */
 
 export class PfTooltip extends HTMLElement {
@@ -24,7 +24,7 @@ export class PfTooltip extends HTMLElement {
     this.element = this;
     this.content = this._innerHtml || this.element.innerHTML;
     this.tooltip = null;
-    this._targetSelector = this.getAttribute('targetSelector');
+    this._targetSelector = this.getAttribute('target-selector');
     this._target = this._targetSelector ? document.querySelector(this._targetSelector) : this;
     this._animation = this.getAttribute('animation') ? this.getAttribute('animation') : 'fade';
     this._placement = this.getAttribute('placement') ? this.getAttribute('placement') : 'right';
@@ -32,7 +32,7 @@ export class PfTooltip extends HTMLElement {
     this._mouseHover = ('onmouseleave' in document) ? [ 'mouseenter', 'mouseleave'] : [ 'mouseover', 'mouseout' ];
     this._tipPositions = /\b(top|bottom|left|top)+/;
     this._duration = pfUtil.isMSIE && pfUtil.isMSIE < 10 ? 0 : (parseInt(this.getAttribute('duration')) || 150);
-    this._containerSelector = this.getAttribute('containerSelector');
+    this._containerSelector = this.getAttribute('container-selector');
     this._container = this._containerSelector ? document.querySelector(this._containerSelector) : document.body;
 
     if (this._target) {
@@ -64,7 +64,7 @@ export class PfTooltip extends HTMLElement {
    * Only attributes listed in the observedAttributes property will receive this callback
    */
   static get observedAttributes() {
-    return ['animation', 'targetSelector', 'placement', 'delay', 'duration', 'containerSelector'];
+    return ['animation', 'target-selector', 'placement', 'delay', 'duration', 'container-selector'];
   }
 
   /**
@@ -119,7 +119,7 @@ export class PfTooltip extends HTMLElement {
   }
 
   /**
-   * Get the tooltip containerSelector
+   * Get the tooltip container-selector
    *
    * @returns {string} The container element selector
    */
@@ -128,7 +128,7 @@ export class PfTooltip extends HTMLElement {
   }
 
   /**
-   * Set the tooltip containerSelector
+   * Set the tooltip container-selector
    *
    * @param {string} value The container element selector
    */
@@ -136,7 +136,7 @@ export class PfTooltip extends HTMLElement {
     if (this._containerSelector !== value) {
       this._containerSelector = value;
       this._container = document.querySelector(this._containerSelector);
-      this.setAttribute('containerSelector', value);
+      this.setAttribute('container-selector', value);
     }
   }
 
@@ -204,7 +204,7 @@ export class PfTooltip extends HTMLElement {
   }
 
   /**
-   * Get the targetSelector
+   * Get the target-selector
    *
    * @returns {string} The target element selector
    */
@@ -213,7 +213,7 @@ export class PfTooltip extends HTMLElement {
   }
 
   /**
-   * Set targetSelector
+   * Set target-selector
    *
    * @param {string} value The target element selector
    */
@@ -221,7 +221,7 @@ export class PfTooltip extends HTMLElement {
     if (this._targetSelector !== value) {
       this._targetSelector = value;
       this._target = document.querySelector(this._targetSelector);
-      this.setAttribute('targetSelector', value);
+      this.setAttribute('target-selector', value);
     }
   }
 

--- a/src/pf-tooltip/pf-tooltip.spec.js
+++ b/src/pf-tooltip/pf-tooltip.spec.js
@@ -14,7 +14,7 @@ describe ("PatternFly Tooltip Component Tests", function () {
 
   it('should create the tooltip on open and destroy on close', function (done) {
     render('<button id="btn">Button</button>');
-    render('<pf-tooltip id="tooltip" placement="left" targetSelector="#btn">Would you look at that!</pf-tooltip>');
+    render('<pf-tooltip id="tooltip" placement="left" target-selector="#btn">Would you look at that!</pf-tooltip>');
 
     button = document.querySelector('#btn');
     customElement = document.querySelector('#tooltip');


### PR DESCRIPTION
Issue: #53 
List of components whose attribute names are changed:

- `pf-modal`: 
  &nbsp;&nbsp;&nbsp;`targetSelector` to `target-selector`
  &nbsp;&nbsp;&nbsp;`modalTitle` to `modal-title`
-  `pf-tabs`:
   &nbsp;&nbsp;&nbsp;`tabTitle` to `tab-title`
- `pf-tooltip`:
    &nbsp;&nbsp;&nbsp;`targetSelector` to `target-selector`
     &nbsp;&nbsp;&nbsp;`containerSelector` to `container-selector`

https://rawgit.com/sahil143/patternfly-webcomponents/update-attribute-dist/index.html