### PR TITLE
Clean up custom event names

### DIFF
--- a/src/pf-dropdown/index.html
+++ b/src/pf-dropdown/index.html
@@ -97,7 +97,7 @@
     }
     else {
       //wait for initialization
-      dropdown.addEventListener('initialized', function (event) {
+      dropdown.addEventListener('pf-dropdown.initialized', function (event) {
         dropdown.toggle();
       });
     }

--- a/src/pf-dropdown/pf-dropdown.component.js
+++ b/src/pf-dropdown/pf-dropdown.component.js
@@ -60,7 +60,7 @@ export class PfDropdown extends HTMLElement {
     this.disableClick();
 
     this.initialized = true;
-    this.dispatchEvent(new CustomEvent('initialized', {}));
+    this.dispatchEvent(new CustomEvent('pf-dropdown.initialized', {}));
   }
 
   /**
@@ -99,7 +99,7 @@ export class PfDropdown extends HTMLElement {
         if (items[i].parentNode.classList.contains('disabled')) {
           return false;
         }
-        self.dispatchEvent(new CustomEvent('itemClicked', {}));
+        self.dispatchEvent(new CustomEvent('pf-dropdown.itemClicked', {}));
         return true;
       };
     }
@@ -116,11 +116,11 @@ export class PfDropdown extends HTMLElement {
     let active = /\bopen/.test(button.parentNode.className);
     if (!active) {
       this._detectTouch();
-      this.dispatchEvent(new CustomEvent('show.bs.dropdown', {}));
+      this.dispatchEvent(new CustomEvent('pf-dropdown.show', {}));
       button.focus();
       button.setAttribute('aria-expanded', 'true');
       button.parentNode.classList.toggle('open');
-      this.dispatchEvent(new CustomEvent('shown.bs.dropdown', {}));
+      this.dispatchEvent(new CustomEvent('pf-dropdown.shown', {}));
     }
     if (active) {
       this._clearDropdown();
@@ -136,10 +136,10 @@ export class PfDropdown extends HTMLElement {
     if (backdrop) {
       backdrop.parentNode.removeChild(backdrop);
     }
-    this.dispatchEvent(new CustomEvent('hide.bs.dropdown', {}));
+    this.dispatchEvent(new CustomEvent('pf-dropdown.hide', {}));
     button.setAttribute('aria-expanded', 'false');
     button.parentNode.classList.remove('open');
-    this.dispatchEvent(new CustomEvent('hidden.bs.dropdown', {}));
+    this.dispatchEvent(new CustomEvent('pf-dropdown.hidden', {}));
   }
 
   /**

--- a/src/pf-dropdown/pf-dropdown.spec.js
+++ b/src/pf-dropdown/pf-dropdown.spec.js
@@ -9,7 +9,7 @@ describe("Patternfly Dropdown Component Test", function () {
       done();
     } else {
       //wait for initialization
-      customElement.addEventListener('initialized', function (event) {
+      customElement.addEventListener('pf-dropdown.initialized', function (event) {
         done();
       });
     }
@@ -23,14 +23,14 @@ describe("Patternfly Dropdown Component Test", function () {
     let button = customElement.querySelector('#button');
     //open dropdown
     customElement.toggle();
-    customElement.addEventListener('shown.bs.dropdown', function () {
+    customElement.addEventListener('pf-dropdown.shown', function () {
       expect(button.parentNode.classList.contains('open')).toBe(true);
 
       //close dropdown
       customElement.toggle();
     }, false);
 
-    customElement.addEventListener('hidden.bs.dropdown', function () {
+    customElement.addEventListener('pf-dropdown.hidden', function () {
       expect(button.parentNode.classList.contains('open')).toBe(false);
     }, false);
     done();
@@ -51,7 +51,7 @@ describe("Patternfly Dropdown Component Test", function () {
     let result = false;
     expect(buttonText.innerText).toBe('Dropdown');
     expect(item.innerText).toBe('Item 1');
-    customElement.addEventListener('itemClicked', function () {
+    customElement.addEventListener('pf-dropdown.itemClicked', function () {
       result = true;
     });
     item.click();
@@ -62,7 +62,7 @@ describe("Patternfly Dropdown Component Test", function () {
     let item = customElement.querySelector('ul.dropdown-menu  li.disabled a');
     let result = false;
     // custom event is not fired for disabled item
-    customElement.addEventListener('itemClicked', function () {
+    customElement.addEventListener('pf-dropdown.itemClicked', function () {
       result = true;
     });
     item.click();

--- a/src/pf-list-view/index.html
+++ b/src/pf-list-view/index.html
@@ -72,11 +72,11 @@
 
   var demoEvents = document.querySelector('#demoEvents');
 
-  this.addEventListener("RowSelectionChanged", function (e) {
+  this.addEventListener("pf-list-view.RowSelectionChanged", function (e) {
     demoEvents.innerHTML = e.detail.value + "\n" + demoEvents.innerHTML;
   });
 
-  this.addEventListener("ListViewItemActionInitiated", function (e) {
+  this.addEventListener("pf-list-view.ItemActionInitiated", function (e) {
     demoEvents.innerHTML = "Action '" + e.detail.actionType + "' initiated for item: '" + e.detail.itemId + "'\n" + demoEvents.innerHTML;
   });
 </script>

--- a/src/pf-list-view/pf-list-view.component.js
+++ b/src/pf-list-view/pf-list-view.component.js
@@ -31,7 +31,7 @@ export class PfListView extends HTMLElement {
     super();
     // Listen for when the child template-repeater updates it's content
     // ie. repeates the user defined template and replaces $(name) with actual values
-    this.addEventListener("RepeaterContentChanged", function (e) {
+    this.addEventListener("pf-template-repeater.ContentChanged", function (e) {
       this.handleRepeaterContentChanged();
     });
   }
@@ -153,8 +153,8 @@ export class PfListView extends HTMLElement {
     let actionType = e.currentTarget.actionType;
     let itemId = e.currentTarget.itemId;
 
-    let event = new CustomEvent('ListViewItemActionInitiated', {"actionType": actionType, "itemId": itemId});
-    event.initCustomEvent('ListViewItemActionInitiated', true, true, {"actionType": actionType, "itemId": itemId});
+    let event = new CustomEvent('pf-list-view.ItemActionInitiated', {"actionType": actionType, "itemId": itemId});
+    event.initCustomEvent('pf-list-view.ItemActionInitiated', true, true, {"actionType": actionType, "itemId": itemId});
     this.dispatchEvent(event);
   }
 
@@ -181,8 +181,8 @@ export class PfListView extends HTMLElement {
         let itemId = checkbox.parentNode.parentNode.lastElementChild.innerText.replace(/\s+/g, ' ').trim();
         checkbox.value = itemId;
         // there can only be one
-        checkbox.removeEventListener("change", handleCheckboxChange);
-        checkbox.addEventListener("change", handleCheckboxChange);
+        checkbox.removeEventListener("pf-list-view.change", handleCheckboxChange);
+        checkbox.addEventListener("pf-list-view.change", handleCheckboxChange);
       }
     }
 
@@ -193,8 +193,8 @@ export class PfListView extends HTMLElement {
       checkbox.parentNode.parentNode.parentNode.classList.toggle('active');
 
       let msg = (checkbox.checked ? "Selected: " : "Unselected: ") + checkbox.value;
-      let event = new CustomEvent('RowSelectionChanged', {"value": msg});
-      event.initCustomEvent('RowSelectionChanged', true, true, {"value": msg});
+      let event = new CustomEvent('pf-list-view.RowSelectionChanged', {"value": msg});
+      event.initCustomEvent('pf-list-view.RowSelectionChanged', true, true, {"value": msg});
       this.dispatchEvent(event);
     }
   }

--- a/src/pf-tabs/pf-tabs.component.js
+++ b/src/pf-tabs/pf-tabs.component.js
@@ -295,7 +295,7 @@ export class PfTabs extends HTMLElement {
     }.bind(this));
 
     //dispatch the custom 'tabChanged' event for framework listeners
-    this.dispatchEvent(new CustomEvent('tabChanged', { detail: activeTabTitle }));
+    this.dispatchEvent(new CustomEvent('pf-tabs.tabChanged', { detail: activeTabTitle }));
   }
 }
 

--- a/src/pf-template-repeater/pf-template-repeater.component.js
+++ b/src/pf-template-repeater/pf-template-repeater.component.js
@@ -28,8 +28,8 @@ class PFTemplateRepeater extends HTMLElement {
     }
 
     // dispatch a 'repeater content changed' event
-    let event = new CustomEvent('RepeaterContentChanged', {});
-    event.initCustomEvent('RepeaterContentChanged', true, true, {});
+    let event = new CustomEvent('pf-template-repeater.ContentChanged', {});
+    event.initCustomEvent('pf-template-repeater.ContentChanged', true, true, {});
     this.dispatchEvent(event);
 
     return this.innerHTML;

--- a/src/pf-tooltip/pf-tooltip.component.js
+++ b/src/pf-tooltip/pf-tooltip.component.js
@@ -55,7 +55,7 @@ export class PfTooltip extends HTMLElement {
     this.init();
 
     //handleContentChanged
-    this.element.addEventListener('handleContentChanged', (e) => {
+    this.element.addEventListener('pf-tooltip.handleContentChanged', (e) => {
       this.init();
     }, false);
   }
@@ -94,7 +94,7 @@ export class PfTooltip extends HTMLElement {
    */
   setInnerHtml(html) {
     this._innerHtml = html;
-    this.element.dispatchEvent(new CustomEvent('handleContentChanged', {}));
+    this.element.dispatchEvent(new CustomEvent('pf-tooltip.handleContentChanged', {}));
   }
 
   /**
@@ -236,7 +236,7 @@ export class PfTooltip extends HTMLElement {
         this._styleTooltip();
         this._showTooltip();
         //notify frameworks
-        this.dispatchEvent(new CustomEvent('tooltipOpened', {}));
+        this.dispatchEvent(new CustomEvent('pf-tooltip.opened', {}));
       }
     }, 20 );
   }
@@ -252,7 +252,7 @@ export class PfTooltip extends HTMLElement {
         setTimeout(() => {
           this._removeTooltip();
           //notify frameworks
-          this.dispatchEvent(new CustomEvent('tooltipClosed', {}));
+          this.dispatchEvent(new CustomEvent('pf-tooltip.closed', {}));
         }, this._duration);
       }
     }, this._delay + this._duration);

--- a/src/pf-tooltip/pf-tooltip.spec.js
+++ b/src/pf-tooltip/pf-tooltip.spec.js
@@ -23,7 +23,7 @@ describe ("PatternFly Tooltip Component Tests", function () {
     //https://github.com/karma-runner/karma-phantomjs-launcher/issues/19
     customElement.open();
 
-    customElement.addEventListener('tooltipOpened', function () {
+    customElement.addEventListener('pf-tooltip.opened', function () {
       let tooltip = document.querySelector('.tooltip');
       let tooltipText = tooltip.innerText.replace(/(\r\n|\n|\r)/gm,""); //remove any newlines rendered in Phantom
 
@@ -32,7 +32,7 @@ describe ("PatternFly Tooltip Component Tests", function () {
       customElement.close();
     }, false);
 
-    customElement.addEventListener('tooltipClosed', function () {
+    customElement.addEventListener('pf-tooltip.closed', function () {
       expect(document.querySelector('.tooltip')).toBe(null);
       done();
     }, false);

--- a/src/pf-utilization-bar-chart/index.html
+++ b/src/pf-utilization-bar-chart/index.html
@@ -56,7 +56,7 @@
     }, 500);
 
     // Listen for the threshold changed event.
-    document.addEventListener('thresholdSet', function (e) {
+    document.addEventListener('pf-utilization-bar-chart.thresholdSet', function (e) {
       var id = e.detail.id;
       if(id === 'thresholdExample1') {
           var threshold = e.detail.threshold;

--- a/src/pf-utilization-bar-chart/pf-utilization-bar-chart.component.js
+++ b/src/pf-utilization-bar-chart/pf-utilization-bar-chart.component.js
@@ -115,8 +115,8 @@ export class PfUtilizationBarChart extends HTMLElement {
       }
 
       if (thresholdClass !== this._lastThresholdClass) {
-        let event = new CustomEvent('thresholdSet', {'id':this.getAttribute('id'), 'threshold':thresholdClass});
-        event.initCustomEvent('thresholdSet', true, true, {'id':this.getAttribute('id'), 'threshold':thresholdClass});
+        let event = new CustomEvent('pf-utilization-bar-chart.thresholdSet', {'id':this.getAttribute('id'), 'threshold':thresholdClass});
+        event.initCustomEvent('pf-utilization-bar-chart.thresholdSet', true, true, {'id':this.getAttribute('id'), 'threshold':thresholdClass});
         usedBar.classList.remove(this._lastThresholdClass);
         usedBar.classList.add(thresholdClass);
         this._lastThresholdClass = thresholdClass;


### PR DESCRIPTION
issue: #35 

List of components whose event names are changed:

- pf-dropdown
- pf-list-view
- pf-tabs
- pf-template-repeater
- pf-tooltip
- pf-utilization-bar-chart