### PR TITLE
Semantic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: node_js
 node_js:
   - '7'
+
 dist: trusty # needs Ubuntu Trusty
 sudo: false  # no need for virtualization.
 addons:
   chrome: stable # have Travis install chrome stable.
+
 env:
   global:
     - ENCRYPTION_LABEL: "d7ffc1eaa225"
@@ -14,7 +16,7 @@ env:
 
 before_install:
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
-  - npm install git+https://github.com/patternfly/patternfly-eng-release.git
+  - npm install patternfly-eng-release
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
@@ -25,4 +27,11 @@ script:
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -w
 
 after_success:
+  - 'if [[ "$TRAVIS_SECURE_ENV_VARS" = "true" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
+       npm run semantic-release;
+     fi'
   - npm run publish-travis
+
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ https://patternfly-webcomponents.github.io/patternfly-webcomponents/
 ### Build
     npm install
     gulp build
+
 ### Serve
     gulp serve
 URL: http://localhost:3000/index.html
@@ -50,3 +51,36 @@ Repository uses the following:
 If you choose to include components individually, you will also want to include `dist\js\customElementShim.js`. This resolves an issue currently with the HTMLElement prototype in Safari.
 
 [Source](https://github.com/babel/babel/issues/1548)
+
+## Git Commit Guidelines
+
+PatternFly Web Components uses a semantic release process to automate package publishing, based on the following commit message format.
+
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject** ([full explanation](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)):
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+##### Patch Release
+
+```
+fix(pencil): stop graphite breaking when too much pressure applied
+```
+
+##### Feature Release
+
+```
+feat(pencil): add 'graphiteWidth' option
+```
+
+##### Breaking Release
+
+```
+perf(pencil): remove graphiteWidth option
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patternfly-webcomponents",
-  "version": "0.0.9",
+  "version": "0.0.0-semantically-released",
   "description": "PatternFly Web Components",
   "main": "dist/js/index.js",
   "author": "Red Hat",
@@ -33,9 +33,10 @@
     "karma-chrome-launcher": "^2.0.0",
     "karma-jasmine": "^1.0.2",
     "patternfly-eng-publish": "0.0.3",
-    "patternfly-eng-release": "3.21.0",
+    "patternfly-eng-release": "^3.26.35",
     "promise-polyfill": "^6.0.2",
     "run-sequence": "^1.2.2",
+    "semantic-release": "^6.3.6",
     "webpack": "^3.3.0",
     "webpack-bundle-analyzer": "^2.8.3",
     "webpack-stream": "~3.2.0"
@@ -46,12 +47,16 @@
     "font-awesome": "^4.7.0",
     "patternfly": "^3.21.0"
   },
+  "release": {
+    "branch": "master-dist",
+    "debug": false
+  },
   "scripts": {
-    "publish": "publish-ghpages.sh public",
     "publish-travis": "publish-ghpages.sh -t public",
     "test": "gulp test",
     "start": "gulp build; gulp serve & open http://localhost:3000/index.html;",
-    "build": "gulp build"
+    "build": "gulp build",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added semantic release to create a new package versions from master-dist.

Note that the patternfly-eng-release scripts will continue to run npm install, bower install, grunt build, grunt ngdocs:publish, npm test, nsp shrinkwrap audit, and will verify npm/bower installs. An npm shrinkwrap file will also be created and committed to master-dist along with other generated files. The scripts will continue to ensure master-dist is not published during pull requests and tagged builds -- it must be a merge to master and not a fork.