### PR TITLE
Bump patternfly-eng-release version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "karma-chrome-launcher": "^2.0.0",
     "karma-jasmine": "^1.0.2",
     "patternfly-eng-publish": "0.0.3",
-    "patternfly-eng-release": "3.21.0",
+    "patternfly-eng-release": "^3.26.6",
     "promise-polyfill": "^6.0.2",
     "run-sequence": "^1.2.2",
     "webpack": "^3.3.0",


### PR DESCRIPTION
Changes were made to the patternfly-eng-release scripts to support semantic releases. Until the PR is merged, Travis will fail because it does not have the latest scripts.

https://github.com/patternfly-webcomponents/patternfly-webcomponents/pull/65