### PR TITLE
feat(pfTabs): enhance pf-tabs api

### DIFF
--- a/src/pf-dropdown/pf-dropdown.component.js
+++ b/src/pf-dropdown/pf-dropdown.component.js
@@ -26,7 +26,7 @@ export class PfDropdown extends HTMLElement {
    * Called every time the element is inserted into the DOM
    */
   connectedCallback() {
-    this._button = this.querySelector('.btn');
+    this._button = this.querySelector('.dropdown-toggle');
     this._disabled = /\bdisabled/.test(this._button.className);
     let menu = this.querySelector('.dropdown-menu');
 
@@ -109,7 +109,7 @@ export class PfDropdown extends HTMLElement {
    *
    */
   _showDropdown() {
-    let button = this.querySelector('.btn');
+    let button = this.querySelector('.dropdown-toggle');
     if (/\bdisabled/.test(button.className)) {
       return;
     }
@@ -131,7 +131,7 @@ export class PfDropdown extends HTMLElement {
    *
    */
   _clearDropdown() {
-    let button = this.querySelector('.btn');
+    let button = this.querySelector('.dropdown-toggle');
     let backdrop = this.querySelector('.dropdown-backdrop');
     if (backdrop) {
       backdrop.parentNode.removeChild(backdrop);

--- a/src/pf-dropdown/pf-dropdown.spec.js
+++ b/src/pf-dropdown/pf-dropdown.spec.js
@@ -37,7 +37,7 @@ describe("Patternfly Dropdown Component Test", function () {
   });
 
   it("disabled button should not open dropdown", function () {
-    let button = customElement.querySelector('.btn');
+    let button = customElement.querySelector('.dropdown-toggle');
     button.classList.add('disabled');
     customElement.toggle();
     expect(button.parentNode.classList.contains('open')).toBe(false);
@@ -46,7 +46,7 @@ describe("Patternfly Dropdown Component Test", function () {
   });
 
   it("should select an element", function () {
-    let buttonText = customElement.querySelector('.btn');
+    let buttonText = customElement.querySelector('.dropdown-toggle');
     let item = customElement.querySelector('ul.dropdown-menu > li:nth-child(2) a');
     let result = false;
     expect(buttonText.innerText).toBe('Dropdown');

--- a/src/pf-tabs/index.html
+++ b/src/pf-tabs/index.html
@@ -6,6 +6,11 @@
   <link rel="stylesheet" href="../../dist/css/patternfly.css">
   <link rel="stylesheet" href="../../dist/css/patternfly-additions.css">
   <link rel="stylesheet" href="../../dist/css/patternfly-webcomponents.css">
+  <style>
+      .pf-tabrow-contents button {
+        margin-left: 5px;
+      }
+  </style>
 </head>
 
 <body>
@@ -13,41 +18,264 @@
     <div class="page-header">
       <h1>Tabs</h1>
     </div>
-    <pf-tabs>
-      <pf-tab tab-title="Tab One" active="true">
-        <p>Tab one content here</p>
-      </pf-tab>
-      <pf-tab tab-title="Tab Two">
-        <p>Tab two content here</p>
-      </pf-tab>
-    </pf-tabs>
 
     <pf-tabs>
-      <pf-tab tab-title="Tab One" active="true">
-        <pf-tabs class="nav nav-tabs nav-tabs-pf">
-          <pf-tab tab-title="Tab One Secondary Tab One" active="true">
-            <p>Tab One Secondary Tab One content.</p>
-          </pf-tab>
-          <pf-tab tab-title="Tab One Secondary Tab Two">
-            <p>Tab One Secondary Tab Two content.</p>
-          </pf-tab>
-        </pf-tabs>
-      </pf-tab>
-      <pf-tab tab-title="Tab Two">
-        <pf-tabs class="nav nav-tabs nav-tabs-pf">
-          <pf-tab tab-title="Tab Two Secondary Tab One" active="true">
-            <p>Tab Two Secondary Tab One content.</p>
-          </pf-tab>
-          <pf-tab tab-title="Tab Two Secondary Tab Two">
-            <p>Tab Two Secondary Tab Two content.</p>
-          </pf-tab>
-        </pf-tabs>
+      <pf-tab content-id="example-one-tab-one">Tab One</pf-tab>
+      <pf-tab content-id="example-one-tab-two">Tab Two</pf-tab>
+    </pf-tabs>
+    <pf-tab-content content-id="example-one-tab-one">
+      <p> tab one content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-one-tab-two">
+      <p>tab two content </p>
+    </pf-tab-content>
+
+    <h3>Secondary Tabs</h3>
+    <pf-tabs>
+      <pf-tab content-id="example-two-tab-one">Tab One</pf-tab>
+      <pf-tab content-id="example-two-tab-two">Tab Two</pf-tab>
+    </pf-tabs>
+    <pf-tab-content content-id="example-two-tab-one">
+      <pf-tabs tabs-class="nav nav-tabs nav-tabs-pf">
+        <pf-tab content-id="example-two-tab-one-secondary-one">Tab One Secondary Tab One</pf-tab>
+        <pf-tab content-id="example-two-tab-one-secondary-two">Tab One Secondary Tab Two</pf-tab>
+      </pf-tabs>
+      <pf-tab-content content-id="example-two-tab-one-secondary-one">
+        <p>tab one secondary tab one content</p>
+      </pf-tab-content>
+      <pf-tab-content content-id="example-two-tab-one-secondary-two">
+        <p>tab one secondary tab two content</p>
+      </pf-tab-content>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-two-tab-two">
+      <p>tab two content </p>
+    </pf-tab-content>
+
+
+    <h3>Justified Tabs</h3>
+    <pf-tabs tabs-class="nav nav-tabs nav-justified">
+      <pf-tab content-id="example-three-tab-one">Tab One</pf-tab>
+      <pf-tab content-id="example-three-tab-two">Tab Two</pf-tab>
+      <pf-tab content-id="example-three-tab-three">Tab Three</pf-tab>
+    </pf-tabs>
+    <pf-tab-content content-id="example-three-tab-one">
+      <p> tab one content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-three-tab-two">
+      <p>tab two content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-three-tab-three">
+      <p>tab three content </p>
+    </pf-tab-content>
+
+    <h3>Tabs with Dropdowns</h3>
+    <pf-tabs>
+      <pf-tab content-id="example-four-tab-one">Tab One</pf-tab>
+      <pf-tab content-id="example-four-tab-two">Tab Two</pf-tab>
+      <pf-tab content-id="example-four-tab-three">
+        <pf-dropdown class="dropdown" id="dropdown1">
+          <a class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Dropdown
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li class="dropdown-header">Header</li>
+            <li><a href="#">Item 1</a></li>
+          <li><a href="#">Item 2</a></li>
+          <li class="disabled"><a href="#">Item 3</a></li>
+          <li><a href="#">Item 4</a></li>
+          <li class="divider"></li>
+          <li><a href="#">Item 5</a></li>
+          </ul>
+        </pf-dropdown>
       </pf-tab>
     </pf-tabs>
+    <pf-tab-content content-id="example-four-tab-one">
+      <p> tab one content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-four-tab-two">
+      <p>tab two content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-four-tab-three">
+      <p>tab three content </p>
+    </pf-tab-content>
+
+    <h3>Patternfly Styles</h3>
+    <pf-tabs tabs-class="nav nav-tabs nav-tabs-pf">
+      <pf-tab content-id="example-five-tab-one">Tab One</pf-tab>
+      <pf-tab content-id="example-five-tab-two">Tab Two</pf-tab>
+    </pf-tabs>
+    <pf-tab-content content-id="example-five-tab-one">
+      <p> tab one content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-five-tab-two">
+      <p>tab two content </p>
+    </pf-tab-content>
+
+    <pf-tabs tabs-class="nav nav-tabs nav-tabs-pf nav-justified">
+      <pf-tab content-id="example-six-tab-one">Tab One</pf-tab>
+      <pf-tab content-id="example-six-tab-two">Tab Two</pf-tab>
+      <pf-tab content-id="example-six-tab-six">Tab Three</pf-tab>
+    </pf-tabs>
+    <pf-tab-content content-id="example-six-tab-one">
+      <p> tab one content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-six-tab-two">
+      <p>tab two content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-six-tab-six">
+      <p>tab three content </p>
+    </pf-tab-content>
+
+    <pf-tabs tabs-class="nav nav-tabs nav-tabs-pf">
+      <pf-tab content-id="example-seven-tab-one">Tab One</pf-tab>
+      <pf-tab content-id="example-seven-tab-two">Tab Two</pf-tab>
+      <pf-tab content-id="example-seven-tab-three">
+        <pf-dropdown class="dropdown" id="dropdown1">
+          <a class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Dropdown
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li class="dropdown-header">Header</li>
+            <li><a href="#">Item 1</a></li>
+          <li><a href="#">Item 2</a></li>
+          <li class="disabled"><a href="#">Item 3</a></li>
+          <li><a href="#">Item 4</a></li>
+          <li class="divider"></li>
+          <li><a href="#">Item 5</a></li>
+          </ul>
+        </pf-dropdown>
+      </pf-tab>
+    </pf-tabs>
+    <pf-tab-content content-id="example-seven-tab-one">
+      <p> tab one content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-seven-tab-two">
+      <p>tab two content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-seven-tab-three">
+      <p>tab three content </p>
+    </pf-tab-content>
+
+    <h3>Tab Row Contents</h3>
+    <pf-tabs tabs-class="nav nav-tabs pf-tabrow">
+      <pf-tab content-id="example-eight-tab-one">Tab One</pf-tab>
+      <pf-tab content-id="example-eight-tab-two">Tab Two</pf-tab>
+      <pf-tab-row-contents contents-class="pf-tabrow-contents">
+        <button class="btn btn-default" type="button">Secondary</button>
+        <button class="btn btn-primary" type="button">Primary</button>
+        <button class="btn btn-danger" type="button">Destructive</button>
+      </pf-tab-row-contents>
+    </pf-tabs>
+    <pf-tab-content content-id="example-eight-tab-one">
+      <p> tab one content </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-eight-tab-two">
+      <p>tab two content </p>
+    </pf-tab-content>
+
+    <h3>Changes in Content</h3>
+    <pf-tabs id="dynamicPfTabs" tabs-class="nav nav-tabs pf-tabrow">
+      <pf-tab content-id="example-nine-tab-one">
+        <span id="dynamic-title-one">Tab One</span>
+      </pf-tab>
+      <pf-tab content-id="example-nine-tab-two">
+        <span id="dynamic-title-two">Tab Two</span>
+        <i class="fa fa-bell"></i>
+      </pf-tab>
+      <pf-tab content-id="example-nine-tab-three">
+        <span id="dynamic-title-three">Tab Three</span>
+        <span class="badge">3</span>
+      </pf-tab>
+      <pf-tab-row-contents id="dynamic-tab-row" contents-class="pf-tabrow-contents">
+        <button id="secondary-btn" class="btn btn-default" type="button">Secondary</button>
+        <button id="primary-btn" class="btn btn-primary" type="button">Primary</button>
+        <button id="destructive-btn" class="btn btn-danger" type="button">Destructive</button>
+      </pf-tab-row-contents>
+    </pf-tabs>
+    <pf-tab-content content-id="example-nine-tab-one">
+      <p>
+        <span>Change my titles dynamically. </span>
+        <button id="changeTitles1" class="btn btn-primary"> Click me! </button> 
+      </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-nine-tab-two">
+      <p>
+        <span id="dynamic-content">Change my content dynamically. </span>
+        <button id="changeContent1" class="btn btn-primary"> Click me! </button>
+      </p>
+    </pf-tab-content>
+    <pf-tab-content content-id="example-nine-tab-three">
+      <p>
+        <span>Change my tab row content dynamically. </span>
+        <button id="changeRowContent1" class="btn btn-primary"> Click me! </button>
+      </p>
+    </pf-tab-content>
+
+
+
   </div>
   <script src="//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.0/webcomponents-lite.js"></script>
   <script src="//rawgit.com/webcomponents/custom-elements/master/src/native-shim.js"></script>
   <script src="../../dist/js/patternfly.js"></script>
+  <script>
+    var dynamicPfTabs = document.getElementById('dynamicPfTabs');
+
+    if (dynamicPfTabs.initialized) {
+      listenForChangeClicks();
+    }
+    else {
+      //wait for initialization
+      dynamicPfTabs.addEventListener('pf-tabs.initialized', function (event) {
+        listenForChangeClicks();
+      });
+    }
+
+    function listenForChangeClicks(){
+      //change title contents
+      var changeTitles1Button = document.getElementById('changeTitles1');
+      var dynamicTitleOne = dynamicPfTabs.querySelector('#dynamic-title-one');
+      var dynamicTitleTwo = dynamicPfTabs.querySelector('#dynamic-title-two');
+      var dynamicTitleThree = dynamicPfTabs.querySelector('#dynamic-title-three');
+      changeTitles1Button.onclick = function(e){
+        dynamicTitleOne.innerHTML = "Tab A";
+        dynamicTitleTwo.innerHTML = "Tab B";
+        dynamicTitleThree.innerHTML = "Tab C";
+      }
+
+      //change tab contents
+      var changeContent1Button = document.getElementById('changeContent1');
+      var dynamicContent = document.getElementById('dynamic-content');
+      changeContent1Button.onclick = function(e){
+        dynamicContent.innerHTML = "Ohhh yea, I like this!";
+      }
+
+      //change tab row contents
+      var changeRowContent1Button = document.getElementById('changeRowContent1');
+      var dynamicTabRow = document.getElementById('dynamic-tab-row');
+      var primaryBtn = document.getElementById('primary-btn');
+      var secondaryBtn = document.getElementById('secondary-btn');
+      var destructiveBtn = document.getElementById('destructive-btn');
+
+      changeRowContent1Button.onclick = function(e){
+        primaryBtn.innerHTML = 'Primary Changed';
+        secondaryBtn.innerHTML = 'Secondary Changed';
+        destructiveBtn.innerHTML = 'Destructive Changed';
+      }
+
+      primaryBtn.onclick = function(e){
+        alert('Primary clicked!');
+      }
+      secondaryBtn.onclick = function(e){
+        alert('Secondary clicked!');
+      }
+      destructiveBtn.onclick = function(e){
+        alert('Destructive clicked!');
+      }
+    }
+
+  </script>
 </body>
 
 </html>

--- a/src/pf-tabs/pf-tab-content.component.js
+++ b/src/pf-tabs/pf-tab-content.component.js
@@ -1,5 +1,7 @@
+import { default as tmpl } from 'pf-tab-content.template';
+
 /**
- * <b>&lt;pf-tab&gt;</b> element for Patternfly Web Components
+ * <b>&lt;pf-tab-content&gt;</b> element for Patternfly Web Components
  *
  * @example {@lang xml}
  * <pf-tabs tabs-class="nav nav-tabs">
@@ -16,25 +18,19 @@
  * <pf-tab-content content-id="content1"> <p> my content 1 </p></pf-tab-content>
  * <pf-tab-content content-id="content2"> <p> my content 2 </p></pf-tab-content>
  *
- * @prop {string} tabClass the tab li class
+ * @prop {string} class the tab ul class
  * @prop {string} contentId the content id which describes this tabs content
  * @prop {string} active whether this tab is currently active
  */
-export class PfTab extends HTMLElement {
+export class PfTabContent extends HTMLElement {
   /*
    * Called every time the element is inserted into the DOM
    */
   connectedCallback() {
-    this._tabClass = this.getAttribute('tab-class');
-    this._contentId = this.getAttribute('content-id');
-    this._active = this.getAttribute('active');
-  }
-
-  /*
-   * Only attributes listed in the observedAttributes property will receive this callback
-   */
-  static get observedAttributes() {
-    return ['active'];
+    this.firstElementChild.setAttribute('role', 'tabpanel');
+    this.firstElementChild.setAttribute('aria-labelledby', this.getAttribute('content-id'));
+    this.initialized = true;
+    this.dispatchEvent(new CustomEvent('pf-tab-content.initialized', {}));
   }
 
   /*
@@ -43,27 +39,6 @@ export class PfTab extends HTMLElement {
   constructor() {
     super();
   }
-
-  /**
-   * Get flag indicating tab is active
-   *
-   * @returns {boolean} True if tab is active
-   */
-  get active() {
-    return this._active;
-  }
-
-  /**
-   * Set flag indicating tab is active
-   *
-   * @param {boolean} value True to set tab active
-   */
-  set active(value) {
-    if (this._active !== value) {
-      this._active = value;
-      this.setAttribute('active', value);
-    }
-  }
 }
 
-window.customElements.define('pf-tab', PfTab);
+window.customElements.define('pf-tab-content', PfTabContent);

--- a/src/pf-tabs/pf-tab-content.template.js
+++ b/src/pf-tabs/pf-tab-content.template.js
@@ -1,0 +1,4 @@
+const PfTabContentTemplate = `
+<div role="tabpanel"></div>
+`;
+export { PfTabContentTemplate as default };

--- a/src/pf-tabs/pf-tab-row-contents.component.js
+++ b/src/pf-tabs/pf-tab-row-contents.component.js
@@ -1,0 +1,82 @@
+/**
+ * <b>&lt;pf-tab-row-contents&gt;</b> element for Patternfly Web Components
+ *
+ * @example {@lang xml}
+ * <pf-tabs tabs-class="nav nav-tabs">
+ *  <pf-tab tab-class="nav-item" content-id="content1" active="true">
+ *    Tab One
+ *  </pf-tab>
+ *  <pf-tab tab-class="nav-item" content-id="content2" active="true">
+ *    Tab Two
+ *  </pf-tab>
+ *  <pf-tab-row-contents contents-class="pf-tabrow-contents">
+ *    <button class="btn btn-default" type="button">Default</button>
+ *  </pf-tab-row-contents>
+ * </pf-tabs>
+ * <pf-tab-content content-id="content1"> <p> my content 1 </p></pf-tab-content>
+ * <pf-tab-content content-id="content2"> <p> my content 2 </p></pf-tab-content>
+ *
+ * @prop {string} contentsClass the tab row contents class
+ */
+export class PfTabRowContents extends HTMLElement {
+  /*
+   * An instance of the element is created or upgraded
+   */
+  constructor() {
+    super();
+  }
+
+  /*
+   * Called every time the element is inserted into the DOM
+   */
+  connectedCallback() {
+    this._contentsClass = this.getAttribute('contents-class');
+  }
+
+  /*
+   * Only attributes listed in the observedAttributes property will receive this callback
+   */
+  static get observedAttributes() {
+    return ['contents-class'];
+  }
+
+  /**
+   * Called when element's attribute value has changed
+   *
+   * @param {string} attrName The attribute name that has changed
+   * @param {string} oldValue The old attribute value
+   * @param {string} newValue The new attribute value
+   */
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    if (attrName === 'contents-class' && newValue !== 'ng-isolate-scope') {
+      //the last li within the tabs ul
+      let li = this.parentNode.firstElementChild.lastElementChild;
+      if (li) {
+        li.className = newValue;
+      }
+    }
+  }
+
+  /**
+   * Get tab row contents class
+   *
+   * @returns {string} contents class
+   */
+  get contentsClass() {
+    return this._contentsClass;
+  }
+
+  /**
+   * Set tab row contents class
+   *
+   * @param {string} value contents class
+   */
+  set contentsClass(value) {
+    if (this._contentsClass !== value) {
+      this._contentsClass = value;
+      this.setAttribute('contents-class', value);
+    }
+  }
+}
+
+window.customElements.define('pf-tab-row-conents', PfTab);

--- a/src/pf-tabs/pf-tab-row-contents.template.js
+++ b/src/pf-tabs/pf-tab-row-contents.template.js
@@ -1,0 +1,5 @@
+const PfTabRowContentsTemplate = `
+<li role="section">
+</li>
+`;
+export {PfTabRowContentsTemplate as default};

--- a/src/pf-tabs/pf-tabs.scss
+++ b/src/pf-tabs/pf-tabs.scss
@@ -1,4 +1,39 @@
-pf-tabs.nav.nav-tabs .nav.nav-tabs-pf {
+pf-tabs ul.nav.nav-tabs li,
+pf-tabs ul.nav.nav-tabs li a {
+  cursor: pointer;
+}
+
+pf-tab-content > *:not(ul):not(pf-tab):not(pf-tabs):not(pf-tab-content) {
+  font-size: 14px;
+  padding: 15px;
+}
+
+pf-tab-content {
+  display: none;
+}
+
+pf-tab-content.active {
+  display: block;
+}
+
+pf-tab {
+  display: none;
+}
+
+pf-tabs pf-dropdown > a {
+  color: #4d5258;
+  &:hover {
+    color: #4d5258;
+    text-decoration: none;
+  }
+}
+
+pf-tabs li.active pf-dropdown > a {
+  color: #0088ce;
+}
+
+// secondary tabs
+pf-tab-content > pf-tabs ul.nav.nav-tabs-pf {
   & > li {
     font-size: 12px;
 
@@ -12,12 +47,20 @@ pf-tabs.nav.nav-tabs .nav.nav-tabs-pf {
   }
 }
 
-pf-tabs.nav.nav-tabs li,
-pf-tabs.nav.nav-tabs li a {
-  cursor: pointer;
+// tab row
+pf-tab-row-contents {
+  display: none;
 }
 
-pf-tab > *:not(ul):not(pf-tab):not(pf-tabs) {
-  font-size: 14px;
-  padding: 15px;
+pf-tabs ul.pf-tabrow {
+  display: flex;
+  flex-wrap: wrap-reverse;
+
+  & > li {
+    float: none;
+  }
+  & > .pf-tabrow-contents {
+    margin-left: auto;
+  }
 }
+

--- a/src/pf-utils/pf-utils.js
+++ b/src/pf-utils/pf-utils.js
@@ -105,6 +105,22 @@ class PfUtil {
     }
     return parentHeight;
   }
+
+  getAttributeOrProperty(element, attribute) {
+    // checks element attributes and then properties
+    // React commonly gives us a node with attributes, when Angular adds it as a property
+    return element.attributes && element.attributes[attribute] ?
+      element.attributes[attribute].value : element[attribute];
+  }
+
+  transcludeChildren(fromElement, toElement) {
+    // transcludes all child elements from the fromElement to the toElement,
+    // retaining all event handlers and attributes/props.
+    // cloneNode and innerHTML will not do this like appendChild (which moves the child element)
+    [...fromElement.childNodes].forEach((child) => {
+      toElement.appendChild(child);
+    });
+  }
 }
 
 let pfUtil = new PfUtil();


### PR DESCRIPTION
* enhance pf-tabs API to support DOM nodes within the tabs
* enhance pf-tabs API to support multiple contents via new `pf-tab-content` CE
* enhance pf-tabs to support pf-dropdown tab items
* enhance pf-tabs test page to include several style variations and dynamic contents example
* enhance pf-dropdown to support non `button` dropdown toggles (such as `a` rendered by `pf-tabs`)

test page:
https://rawgit.com/priley86/patternfly-webcomponents/pf-tabs-updates-dist/app/app.html?dir=pf-tabs&file=index.html

stackblitz:
https://using-pf-tabs-in-reactjs.stackblitz.io/

Closes #60